### PR TITLE
Handle multiple transactions, add maxTransactions middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ To setup Patroneos in the simple configuration, a user just needs nodeos running
 * validateJSON
     * This middleware checks that the body provided can be parsed into a JSON object.
 
+* validateMaxTransactions
+    * This middleware checks that the number of transactions in a request does not exceed the defined maximum.
+
 * validateMaxSignatures
     * This middleware checks that the number of signatures on the transaction are not greater than the defined maximum.
 

--- a/docker/proxy/fail2ban/filter.d/contracts.conf
+++ b/docker/proxy/fail2ban/filter.d/contracts.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for patroneos-malformed-json
+# Fail2Ban filter for patroneos-blacklisted-contracts
 #
 #
 

--- a/docker/proxy/fail2ban/filter.d/failed-transactions.conf
+++ b/docker/proxy/fail2ban/filter.d/failed-transactions.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for patroneos-malformed-json
+# Fail2Ban filter for patroneos-failed-transactions
 #
 #
 

--- a/docker/proxy/fail2ban/filter.d/max-transactions.conf
+++ b/docker/proxy/fail2ban/filter.d/max-transactions.conf
@@ -1,0 +1,8 @@
+# Fail2Ban filter for patroneos-max-transactions
+#
+#
+
+[Definition]
+
+failregex = <HOST> .*? TOO_MANY_TRANSACTIONS
+ignoreregex =

--- a/docker/proxy/fail2ban/filter.d/signatures.conf
+++ b/docker/proxy/fail2ban/filter.d/signatures.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for patroneos-malformed-json
+# Fail2Ban filter for patroneos-max-signatures
 #
 #
 

--- a/docker/proxy/fail2ban/filter.d/transaction-size.conf
+++ b/docker/proxy/fail2ban/filter.d/transaction-size.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for patroneos-malformed-json
+# Fail2Ban filter for patroneos-transaction-size
 #
 #
 

--- a/docker/proxy/fail2ban/jail.d/patroneos.conf
+++ b/docker/proxy/fail2ban/jail.d/patroneos.conf
@@ -52,3 +52,14 @@ filter   = failed-transactions
 logpath  = /var/log/patroneosd.log
 maxretry = 3
 action   = docker-iptables-multiport[name=failedTrans, port="443"]
+
+[max-transactions]
+
+bantime  = 300
+findtime = 60
+enabled  = true
+port     = 443
+filter   = max-transactions
+logpath  = /var/log/patroneosd.log
+maxretry = 3
+action   = docker-iptables-multiport[name=maxTrans, port="443"]

--- a/example-configs/advanced/filter-config.json
+++ b/example-configs/advanced/filter-config.json
@@ -10,6 +10,7 @@
     },
     "maxSignatures": 10,
     "maxTransactionSize": 1000000,
+    "maxTransactions": 32,
 
     "logEndpoints": ["http://localhost:8080"],
     "filterEndpoints": [],

--- a/example-configs/simple/config.json
+++ b/example-configs/simple/config.json
@@ -9,5 +9,6 @@
         "currency": true
     },
     "maxSignatures": 10,
-    "maxTransactionSize": 1000000
+    "maxTransactionSize": 1000000,
+    "maxTransactions": 32
 }

--- a/filter.go
+++ b/filter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -39,6 +40,13 @@ type Transaction struct {
 	Signatures     []string      `json:"signatures"`
 	Authorizations []interface{} `json:"authorizations"`
 }
+
+// Define Context Keys
+type contextKey string
+
+var (
+	transactionsKey = contextKey("transactions")
+)
 
 var client = http.Client{}
 
@@ -123,6 +131,8 @@ func validateJSON(next http.HandlerFunc) http.HandlerFunc {
 				logFailure("INVALID_JSON", w, r)
 				return
 			}
+		} else {
+			logFailure("EMPTY_BODY", w, r)
 		}
 
 		next.ServeHTTP(w, r)
@@ -132,21 +142,14 @@ func validateJSON(next http.HandlerFunc) http.HandlerFunc {
 // validateMaxSignatures checks that the transaction does not have more signatures than the max allowed.
 func validateMaxSignatures(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var transaction Transaction
-
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
-		if len(jsonBytes) > 0 {
-			err := json.Unmarshal(jsonBytes, &transaction)
-			if err != nil {
-				logFailure("PARSING_ERROR", w, r)
-				return
-			}
+		transactions := r.Context().Value(transactionsKey).([]Transaction)
+		for _, transaction := range transactions {
 			if len(transaction.Signatures) > appConfig.MaxSignatures {
 				logFailure("INVALID_NUMBER_SIGNATURES", w, r)
 				return
 			}
 		}
+
 		next.ServeHTTP(w, r)
 	}
 }
@@ -154,17 +157,8 @@ func validateMaxSignatures(next http.HandlerFunc) http.HandlerFunc {
 // validateContract checks that the transaction does not act on a blacklisted contract.
 func validateContract(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var transaction Transaction
-
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
-		if len(jsonBytes) > 0 {
-			err := json.Unmarshal(jsonBytes, &transaction)
-			if err != nil {
-				logFailure("PARSING_ERROR", w, r)
-				return
-			}
-
+		transactions := r.Context().Value(transactionsKey).([]Transaction)
+		for _, transaction := range transactions {
 			for _, action := range transaction.Actions {
 				_, exists := appConfig.ContractBlackList[action.Code]
 				if exists {
@@ -180,15 +174,8 @@ func validateContract(next http.HandlerFunc) http.HandlerFunc {
 // validateTransactionSize checks that the transaction data does not exceed the max allowed size.
 func validateTransactionSize(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
-		if len(jsonBytes) > 0 {
-			var transaction Transaction
-			err := json.Unmarshal(jsonBytes, &transaction)
-			if err != nil {
-				logFailure("PARSING_ERROR", w, r)
-				return
-			}
+		transactions := r.Context().Value(transactionsKey).([]Transaction)
+		for _, transaction := range transactions {
 			for _, action := range transaction.Actions {
 				if len(action.Data) > appConfig.MaxTransactionSize {
 					logFailure("INVALID_TRANSACTION_SIZE", w, r)
@@ -197,6 +184,45 @@ func validateTransactionSize(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 		next.ServeHTTP(w, r)
+	}
+}
+
+// getTransactions parses json and returns a slice containing the transactions
+func getTransactions(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var transactions []Transaction
+		var transaction Transaction
+
+		// Read request body
+		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
+
+		// Determine if JSON is a single object or an array of objects
+		body := strings.TrimSpace(string(jsonBytes))
+
+		if strings.HasPrefix(body, "{") {
+			// Single Object
+			err := json.Unmarshal(jsonBytes, &transaction)
+
+			if err != nil {
+				logFailure("PARSE_ERROR", w, r)
+				return
+			}
+
+			transactions = append(transactions, transaction)
+		} else if strings.HasPrefix(body, "[") {
+			// Array of Objects
+			err := json.Unmarshal(jsonBytes, &transactions)
+
+			if err != nil {
+				logFailure("PARSE_ERROR", w, r)
+				return
+			}
+		}
+
+		// Add transactions to request context so subsequent middleware does not have to parse the transactions again
+		ctx := context.WithValue(r.Context(), transactionsKey, transactions)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	}
 }
 
@@ -288,6 +314,7 @@ func addFilterHandlers(mux *http.ServeMux) {
 	// Middleware are executed in the order that they are passed to chainMiddleware.
 	middlewareChain := chainMiddleware(
 		validateJSON,
+		getTransactions,
 		validateTransactionSize,
 		validateMaxSignatures,
 		validateContract,

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ type Config struct {
 	ContractBlackList  map[string]bool `json:"contractBlackList"`
 	MaxSignatures      int             `json:"maxSignatures"`
 	MaxTransactionSize int             `json:"maxTransactionSize"`
+	MaxTransactions    int             `json:"maxTransactions"`
 	LogEndpoints       []string        `json:"logEndpoints"`
 	FilterEndpoints    []string        `json:"filterEndpoints"`
 	LogFileLocation    string          `json:"logFileLocation"`


### PR DESCRIPTION
- Adds support for JSON arrays for push_transactions (each transaction in the array is ran through the middleware) as pointed out in PR #26.
- Add new middleware to restrict the number of transaction for each request.
- Created a new middleware to handle the unmarshalling of the JSON body, and add the transactions slice to the request context. This will allow the unmarshalling of the JSON body to occur only a single time in the middleware chain, with each subsequent middleware referencing the context.