### PR TITLE
Fix for #36

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -36,7 +36,6 @@ type Transaction struct {
 	RefBlockNum    string        `json:"ref_block_num"`
 	RefBlockPrefix string        `json:"ref_block_prefix"`
 	Expiration     string        `json:"expiration"`
-	Scope          []string      `json:"scope"`
 	Actions        []Action      `json:"actions"`
 	Signatures     []string      `json:"signatures"`
 	Authorizations []interface{} `json:"authorizations"`

--- a/filter_test.go
+++ b/filter_test.go
@@ -149,7 +149,6 @@ func TestValidateContract(t *testing.T) {
 		RefBlockNum:    "1",
 		RefBlockPrefix: "eos",
 		Expiration:     "never",
-		Scope:          []string{"testing"},
 		Actions:        []Action{invalidAction},
 		Signatures:     []string{"12345"},
 		Authorizations: []interface{}{"eosio"},
@@ -194,7 +193,6 @@ func TestValidateSignatures(t *testing.T) {
 		RefBlockNum:    "1",
 		RefBlockPrefix: "eos",
 		Expiration:     "never",
-		Scope:          []string{"testing"},
 		Actions: []Action{
 			{
 				Code:          "tokens",
@@ -254,7 +252,6 @@ func TestValidateTransactionSize(t *testing.T) {
 		RefBlockNum:    "1",
 		RefBlockPrefix: "eos",
 		Expiration:     "never",
-		Scope:          []string{"testing"},
 		Actions:        []Action{invalidAction},
 		Signatures:     []string{"12345"},
 		Authorizations: []interface{}{"eosio"},


### PR DESCRIPTION
- Resolves issue #36, which was caused by our incorrect assumption that scope was always an array of strings. In this case,  "/v1/chain/get_table_rows" expects scope to be a string, and sending an array errors out on the nodeos end.