### PR TITLE
Add build script and version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ main
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# dist folder containing compiled Binaries
+dist/**/*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+date="$(date -u +'%Y-%m-%dT%TZ%z')"
+commit=$(git rev-parse HEAD)
+version="$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)"
+go build -ldflags "-X main.commit=$commit -X main.buildDate=$date -X main.version=$version" -o patroneosd

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 date="$(date -u +'%Y-%m-%dT%TZ%z')"
 commit=$(git rev-parse HEAD)
 version="$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)"
-go build -ldflags "-X main.commit=$commit -X main.buildDate=$date -X main.version=$version" -o patroneosd
+go build -ldflags "-X main.commit=$commit -X main.buildDate=$date -X main.version=$version" -o dist/patroneosd

--- a/filter_test.go
+++ b/filter_test.go
@@ -139,19 +139,12 @@ func TestValidateMaxTransactions(t *testing.T) {
 
 func TestValidateContract(t *testing.T) {
 	invalidAction := Action{
-		Code:          "currency",
-		Type:          "transfer",
-		Recipients:    []string{"me"},
-		Authorization: []interface{}{"eosio"},
-		Data:          "1234567890",
+		Code: "currency",
+		Data: "1234567890",
 	}
 	invalidTransaction := Transaction{
-		RefBlockNum:    "1",
-		RefBlockPrefix: "eos",
-		Expiration:     "never",
-		Actions:        []Action{invalidAction},
-		Signatures:     []string{"12345"},
-		Authorizations: []interface{}{"eosio"},
+		Actions:    []Action{invalidAction},
+		Signatures: []string{"12345"},
 	}
 	validTransaction := invalidTransaction
 	validAction := invalidAction
@@ -190,20 +183,13 @@ func TestValidateContract(t *testing.T) {
 
 func TestValidateSignatures(t *testing.T) {
 	invalidTransaction := Transaction{
-		RefBlockNum:    "1",
-		RefBlockPrefix: "eos",
-		Expiration:     "never",
 		Actions: []Action{
 			{
-				Code:          "tokens",
-				Type:          "transfer",
-				Recipients:    []string{"me"},
-				Authorization: []interface{}{"eosio"},
-				Data:          "1234567890",
+				Code: "tokens",
+				Data: "1234567890",
 			},
 		},
-		Signatures:     []string{"12345", "54321"},
-		Authorizations: []interface{}{"eosio"},
+		Signatures: []string{"12345", "54321"},
 	}
 
 	validTransaction := invalidTransaction
@@ -241,20 +227,13 @@ func TestValidateSignatures(t *testing.T) {
 
 func TestValidateTransactionSize(t *testing.T) {
 	invalidAction := Action{
-		Code:          "tokens",
-		Type:          "transfer",
-		Recipients:    []string{"me"},
-		Authorization: []interface{}{"eosio"},
-		Data:          string(bytes.Repeat([]byte("a"), 100)),
+		Code: "tokens",
+		Data: string(bytes.Repeat([]byte("a"), 100)),
 	}
 
 	invalidTransaction := Transaction{
-		RefBlockNum:    "1",
-		RefBlockPrefix: "eos",
-		Expiration:     "never",
-		Actions:        []Action{invalidAction},
-		Signatures:     []string{"12345"},
-		Authorizations: []interface{}{"eosio"},
+		Actions:    []Action{invalidAction},
+		Signatures: []string{"12345"},
 	}
 
 	validTransaction := invalidTransaction

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 // Config defines the application configuration
@@ -26,10 +27,14 @@ type Config struct {
 	Headers            map[string]string `json:"headers"`
 }
 
-var configFile string
-var operatingMode string
-
-var appConfig Config
+var (
+	configFile    string // path to config.json
+	operatingMode string // operating mode (filter or relay)
+	version       string // application version
+	commit        string // sha1 commit hash used to build application
+	buildDate     string // compilation date
+	appConfig     Config // configuration fields
+)
 
 // updateConfig allows the configuration to be updated via POST requests.
 func updateConfig(w http.ResponseWriter, r *http.Request) {
@@ -67,9 +72,16 @@ func parseArgs() {
 		defaultConfigLocation = "./config.json"
 		defaultOperatingMode  = "filter"
 		defaultShowHelp       = false
+		defaultShowVersion    = false
 	)
-	var showHelp bool
+
+	var (
+		showHelp    bool
+		showVersion bool
+	)
+
 	flag.BoolVar(&showHelp, "h", defaultShowHelp, "shows application help")
+	flag.BoolVar(&showVersion, "v", defaultShowVersion, "show application version")
 	flag.StringVar(&configFile, "configFile", defaultConfigLocation, "location of the file used for application configuration")
 	flag.StringVar(&operatingMode, "mode", defaultOperatingMode, "mode in which the application will run")
 
@@ -77,7 +89,23 @@ func parseArgs() {
 
 	if showHelp {
 		flag.Usage()
-		os.Exit(1)
+		os.Exit(0)
+	}
+
+	if showVersion {
+		var buildDateTime string
+
+		date, err := time.Parse("2006-01-02T15:04:05Z-0700", buildDate)
+
+		if err != nil {
+			log.Printf("Error parsing build date: %v", err)
+			buildDateTime = ""
+		} else {
+			buildDateTime = date.In(time.Local).String()
+		}
+
+		fmt.Printf("Version: %v\nGit Commit: %v\nBuilt on: %v\n", version, commit, buildDateTime)
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
- Adds `build.sh` which handles building Patroneos. This was added so that version information can be injected into the binary. 
- Adds "-v" flag to patroneosd that will output build/version information.