### PR TITLE
Add config option for listenIP

### DIFF
--- a/TUTORIAL-SIMPLE.md
+++ b/TUTORIAL-SIMPLE.md
@@ -6,6 +6,7 @@
 ### Configuration
 A sample configuration file is included in the repo and can be tweaked according to your individual needs.
 ```
+listenIP   -- the ip address that Patroneos listens on (defaults to all ip addresses)
 listenPort -- the port that Patroneos listens on
 
 nodeosProtocol -- the protocol nodeos listens on (HTTP vs HTTPS)

--- a/example-configs/advanced/fail2ban-relay-config.json
+++ b/example-configs/advanced/fail2ban-relay-config.json
@@ -1,4 +1,6 @@
 {
+
+    "listenIP": "",
     "listenPort": "8080",
 
     "nodeosProtocol": "http",

--- a/example-configs/advanced/filter-config.json
+++ b/example-configs/advanced/filter-config.json
@@ -1,4 +1,5 @@
 {
+    "listenIP": "",
     "listenPort": "8081",
 
     "nodeosProtocol": "http",

--- a/example-configs/simple/config.json
+++ b/example-configs/simple/config.json
@@ -1,4 +1,5 @@
 {
+    "listenIP": "",
     "listenPort": "8080",
 
     "nodeosProtocol": "http",

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 // Config defines the application configuration
 type Config struct {
+	ListenIP           string            `json:"listenIP"`
 	ListenPort         string            `json:"listenPort"`
 	NodeosProtocol     string            `json:"nodeosProtocol"`
 	NodeosURL          string            `json:"nodeosUrl"`
@@ -141,5 +142,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Fatal(http.ListenAndServe(":"+appConfig.ListenPort, mux))
+	log.Fatal(http.ListenAndServe(appConfig.ListenIP+":"+appConfig.ListenPort, mux))
 }


### PR DESCRIPTION
Adds an option to allow listening only on a specified interface, defaults to blank which was the previous behaviour