### PR TITLE
Remove CORS headers in example configuration

### DIFF
--- a/example-configs/simple/config.json
+++ b/example-configs/simple/config.json
@@ -13,7 +13,6 @@
     "maxTransactionSize": 1000000,
     "maxTransactions": 32,
     "headers": {
-        "Access-Control-Allow-Origin": "*",
-        "Server": ""
+        "Sample-Header": "value"
     }
 }


### PR DESCRIPTION
To prevent an accidental insecure configuration, the CORS headers have been removed from the example configuration.