### PR TITLE
Update docker POC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         network_mode: "host"
     nodeos:
         image: eosio/eos
-        command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir
+        command: /opt/eosio/bin/nodeosd.sh -e --data-dir /opt/eosio/bin/data-dir --http-alias=localhost:8888
         ports:
             - "8888:8888"
             - "9876:9876"

--- a/docker/filter/config.json
+++ b/docker/filter/config.json
@@ -1,18 +1,24 @@
 {
+    "listenIP": "",
     "listenPort": "8081",
+    "configListenPort": "9001",
 
     "nodeosProtocol": "http",
     "nodeosUrl": "localhost",
     "nodeosPort": "8888",
 
     "contractBlackList": {
-        "currency": true
+        "bad": true
     },
+
     "maxSignatures": 10,
     "maxTransactionSize": 500000,
-
-    "logEndpoints": ["http://localhost:8080"],
+    "maxTransactions": 1,
     "filterEndpoints": ["http://localhost:8081"],
 
-    "logFileLocation": "./fail2ban.log"
+    "logFileLocation": "./fail2ban.log",
+    
+    "headers": {
+        "Server": ""
+    }
 }

--- a/docker/proxy/patroneos/config.json
+++ b/docker/proxy/patroneos/config.json
@@ -1,5 +1,7 @@
 {
+    "listenIP": "",
     "listenPort": "8080",
+    "configListenPort": "9000",
 
     "nodeosProtocol": "http",
     "nodeosUrl": "localhost",


### PR DESCRIPTION
The more recent versions of nodeos require --http-alias flags to work properly. Also, the config files have been updated to reflect the addition of ```configListenPort```